### PR TITLE
I replace date enum with uint64 for greater flexibility in the protocol.

### DIFF
--- a/src/interfaces/ICrowdmuseEscrowMinter.sol
+++ b/src/interfaces/ICrowdmuseEscrowMinter.sol
@@ -55,12 +55,4 @@ interface ICrowdmuseEscrowMinter {
         address indexed erc20Address,
         uint256 totalRefunded
     );
-
-    /// @notice Enumerates the minimum durations (in days) that can be set for an escrow period.
-    enum MinimumEscrowDuration {
-        Days15, // Represents a minimum duration of 15 days.
-        Days30, // Represents a minimum duration of 30 days.
-        Days60, // Represents a minimum duration of 60 days.
-        Days90 // Represents a minimum duration of 90 days.
-    }
 }

--- a/src/minters/CrowdmuseEscrowMinter.sol
+++ b/src/minters/CrowdmuseEscrowMinter.sol
@@ -111,14 +111,11 @@ contract CrowdmuseEscrowMinter is
     /// @notice Configures the sale for a specific product by setting various parameters including the sale duration based on a predefined enum.
     /// @dev This function sets the sale configuration for the target contract and emits a SaleSet event upon successful execution.
     /// @param target The address of the target contract for which the sale configuration is being set.
-    /// @param duration The minimum escrow duration selected from the MinimumEscrowDuration enum.
+    /// @param saleEnd The end of the escrow sale period.
     function setSale(
         address target,
-        MinimumEscrowDuration duration
+        uint64 saleEnd
     ) external onlyOwner(target) onlyIfInactive(target) {
-        uint64 minimumNumberDays = getDaysForEnum(duration);
-        uint64 saleEnd = uint64(block.timestamp + (minimumNumberDays * 1 days));
-
         ICrowdmuseProduct product = ICrowdmuseProduct(target);
         SalesConfig memory salesConfig = SalesConfig({
             saleStart: uint64(block.timestamp),
@@ -335,23 +332,6 @@ contract CrowdmuseEscrowMinter is
     /// @return bool Returns true if the caller is the owner of the target contract.
     function isOwner(address target) internal view returns (bool) {
         return Ownable(target).owner() == msg.sender;
-    }
-
-    /// @dev Converts a MinimumEscrowDuration enum value to its corresponding number of days.
-    /// @param duration The duration value of the enum MinimumEscrowDuration.
-    /// @return durationDays The number of days corresponding to the enum value.
-    function getDaysForEnum(
-        MinimumEscrowDuration duration
-    ) internal pure returns (uint64 durationDays) {
-        if (duration == MinimumEscrowDuration.Days15) {
-            durationDays = 15;
-        } else if (duration == MinimumEscrowDuration.Days30) {
-            durationDays = 30;
-        } else if (duration == MinimumEscrowDuration.Days60) {
-            durationDays = 60;
-        } else if (duration == MinimumEscrowDuration.Days90) {
-            durationDays = 90;
-        }
     }
 
     function getRefundSplit(

--- a/test/minter/CrowdmuseEscrowMinter.t.sol
+++ b/test/minter/CrowdmuseEscrowMinter.t.sol
@@ -100,7 +100,8 @@ contract CrowdmuseEscrowMinterTest is
         // Attempt to set sale config as a non-owner should fail
         vm.prank(address(nonAdmin));
         vm.expectRevert(expectedError);
-        minter.setSale(address(product), MinimumEscrowDuration.Days90);
+        uint64 saleEnd = uint64(block.timestamp + (90 * 1 days));
+        minter.setSale(address(product), saleEnd);
 
         _setSale();
 
@@ -195,7 +196,8 @@ contract CrowdmuseEscrowMinterTest is
 
         // Attempt to set the sale again for the same product
         vm.prank(admin);
-        minter.setSale(address(product), MinimumEscrowDuration.Days90);
+        uint64 saleEnd = uint64(block.timestamp + (90 * 1 days));
+        minter.setSale(address(product), saleEnd);
     }
 
     function test_MintFlow() external {
@@ -559,7 +561,8 @@ contract CrowdmuseEscrowMinterTest is
     function _setSale() internal {
         // Set sale config as the owner should succeed
         vm.prank(admin);
-        minter.setSale(address(product), MinimumEscrowDuration.Days90);
+        uint64 saleEnd = uint64(block.timestamp + (90 * 1 days));
+        minter.setSale(address(product), saleEnd);
     }
 
     function _mintToTokenRecipient(uint256 quantity) internal {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the sale configuration process to use a specific end timestamp (`saleEnd`) instead of predefined duration enums.
  
- **Bug Fixes**
  - Improved the flexibility of sale duration settings by allowing direct timestamp inputs.

- **Refactor**
  - Simplified the logic for setting sale durations by removing the `MinimumEscrowDuration` enum and related calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->